### PR TITLE
Fix theme persistence

### DIFF
--- a/src/main/kotlin/io/paleocrafter/chronomorph/ChronomorphSettings.kt
+++ b/src/main/kotlin/io/paleocrafter/chronomorph/ChronomorphSettings.kt
@@ -99,7 +99,7 @@ class ChronomorphSettings : PersistentStateComponent<Element> {
 
     data class ChronoEntry(val time: LocalTime, val theme: String?, val colorScheme: String?) {
         val themeInfo: UIManager.LookAndFeelInfo?
-            get() = LafManager.getInstance().installedLookAndFeels.find { it.className == theme }
+            get() = LafManager.getInstance().installedLookAndFeels.find { it.name == theme }
         val colorSchemeInfo: EditorColorsScheme?
             get() = EditorColorsManager.getInstance().allSchemes.find { it.name == colorScheme }
     }

--- a/src/main/kotlin/io/paleocrafter/chronomorph/config/ChronoEntryEditor.kt
+++ b/src/main/kotlin/io/paleocrafter/chronomorph/config/ChronoEntryEditor.kt
@@ -65,7 +65,7 @@ class ChronoEntryEditor(title: String, entry: ChronomorphSettings.ChronoEntry?) 
     val entry: ChronomorphSettings.ChronoEntry
         get() = ChronomorphSettings.ChronoEntry(
             LocalTime.of(hourSpinner.value as Int, minuteSpinner.value as Int),
-            themeComboBox.value?.className,
+            themeComboBox.value?.name,
             colorSchemeComboBox.value?.name
         )
 

--- a/src/main/kotlin/io/paleocrafter/chronomorph/config/ChronomorphConfigurable.kt
+++ b/src/main/kotlin/io/paleocrafter/chronomorph/config/ChronomorphConfigurable.kt
@@ -171,9 +171,9 @@ class ChronomorphConfigurable : Configurable {
         return useDayCycleCheckBox.isSelected != settings.useDayCycle
             || latitudeField.text != settings.latitude
             || longitudeField.text != settings.longitude
-            || dayThemeComboBox.value?.className != settings.daySettings.theme
+            || dayThemeComboBox.value?.name != settings.daySettings.theme
             || dayColorSchemeComboBox.value?.name != settings.daySettings.colorScheme
-            || nightThemeComboBox.value?.className != settings.nightSettings.theme
+            || nightThemeComboBox.value?.name != settings.nightSettings.theme
             || nightColorSchemeComboBox.value?.name != settings.nightSettings.colorScheme
             || entryTable.entries != settings.chronoEntries
     }
@@ -187,11 +187,11 @@ class ChronomorphConfigurable : Configurable {
         settings.longitude = longitudeField.text
 
         settings.daySettings = settings.daySettings.copy(
-            theme = dayThemeComboBox.value?.className,
+            theme = dayThemeComboBox.value?.name,
             colorScheme = dayColorSchemeComboBox.value?.name
         )
         settings.nightSettings = settings.nightSettings.copy(
-            theme = nightThemeComboBox.value?.className,
+            theme = nightThemeComboBox.value?.name,
             colorScheme = nightColorSchemeComboBox.value?.name
         )
 


### PR DESCRIPTION
Fixes #1, fixes #5 

I've found out that for all the themes `className` returned by `LafManager.getInstance()` seems to be either `com.intellij.ide.ui.laf.IntelliJLaf` or `com.intellij.ide.ui.laf.darcula.DarculaLaf` which makes it impossible to use any other theme besides Default and Darcula.

Switching persisted theme data to `name` works just fine so I've settled on that.